### PR TITLE
Initial CMake build skeleton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.24)
+project(Lython LANGUAGES C CXX)
+
+set(CMAKE_C_STANDARD 17)
+set(CMAKE_CXX_STANDARD 17)
+
+set(LLVM_ENABLE_PROJECTS "mlir;llvm")
+set(LLVM_EXTERNAL_PROJECTS ${LLVM_ENABLE_PROJECTS})
+
+include(cmake/LLVMExternalProject.cmake)
+
+add_subdirectory(src)

--- a/cmake/LLVMExternalProject.cmake
+++ b/cmake/LLVMExternalProject.cmake
@@ -1,0 +1,25 @@
+include(FetchContent)
+
+set(LLVM_PROJECT_GIT_REPOSITORY "https://github.com/llvm/llvm-project.git" CACHE STRING "")
+set(LLVM_PROJECT_GIT_TAG "llvmorg-18.1.1" CACHE STRING "")
+
+FetchContent_Declare(
+    llvm-project
+    GIT_REPOSITORY ${LLVM_PROJECT_GIT_REPOSITORY}
+    GIT_TAG ${LLVM_PROJECT_GIT_TAG}
+)
+
+FetchContent_MakeAvailable(llvm-project)
+
+set(LLVM_DIR ${llvm-project_BINARY_DIR}/lib/cmake/llvm)
+set(MLIR_DIR ${llvm-project_BINARY_DIR}/lib/cmake/mlir)
+
+list(APPEND CMAKE_PREFIX_PATH ${LLVM_DIR} ${MLIR_DIR})
+find_package(MLIR REQUIRED CONFIG)
+find_package(LLVM REQUIRED CONFIG)
+
+include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
+include_directories(SYSTEM ${MLIR_INCLUDE_DIRS})
+
+add_subdirectory(${llvm-project_SOURCE_DIR}/llvm ${llvm-project_BINARY_DIR}/llvm)
+add_subdirectory(${llvm-project_SOURCE_DIR}/mlir ${llvm-project_BINARY_DIR}/mlir)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(runtime)

--- a/src/lython/__init__.py
+++ b/src/lython/__init__.py
@@ -18,8 +18,7 @@ __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 import logging
 from typing import Literal, NamedTuple
 
-
-__all__ = []
+__all__: list[str] = []
 
 
 class VersionInfo(NamedTuple):

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(lython_runtime STATIC dummy.c)
+
+target_include_directories(lython_runtime PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/runtime/dummy.c
+++ b/src/runtime/dummy.c
@@ -1,0 +1,1 @@
+int lython_runtime_dummy(void) { return 42; }


### PR DESCRIPTION
## Summary
- CMakeベースのビルドシステム骨格を追加
- LLVM/MLIR を FetchContent する `LLVMExternalProject.cmake` を作成
- ランタイム用のダミーライブラリを配置
- `__init__.py` の型注釈を更新

## Testing
- `isort .`
- `black .`
- `flake8` *(fails: command not found)*
- `mypy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e479f176083268c2be648f085b193